### PR TITLE
feat(dashboard+aux): RL 비율 배지/배지 안정화 추가, 파셜 디바운스 강화, 얼굴/시선 채널 매핑 확장\n…

### DIFF
--- a/docs/PROGRESS_2025-09-13.md
+++ b/docs/PROGRESS_2025-09-13.md
@@ -1,0 +1,28 @@
+# Progress Summary (2025-09-13)
+
+Follow-up work based on 2025-09-12 notes. Focused on safe, incremental improvements without destabilizing core services.
+
+## Done
+- Dashboard UX
+  - Added RL ratio badge next to replace ratio (reads `rate_limit_ratio` from `/stats`).
+  - Stabilized badge color changes using simple moving averages + 5% hysteresis for:
+    - Replace ratio (window 20)
+    - Latency p90 (window 10)
+    - Rate-limit ratio (window 20)
+- Streaming partials debounce
+  - Suppress duplicate partials even when only whitespace/punctuation differ (trim/collapse whitespace and drop trailing punctuation `, . ! ? … ·`).
+
+## Notes
+- No server API surface changes were required for the dashboard updates; it uses existing `/stats` fields.
+- The debounce change is conservative and only affects `partial` messages; `final` messages are unchanged.
+
+## Next (suggested)
+1) Safer replace window
+   - Add `MAX_REPLACE_FUTURE_MS` to settings and limit `timeline.replace` slices to a bounded future window (e.g., 1200ms) to reduce jitter.
+2) Per-session telemetry
+   - Track per-session latency ring and rate-limit counters for session-level p90 and RL ratio in `/sessions_full`.
+3) Face/gaze channel patterns
+   - Expand `_FACE_CLIPS`/`_GAZE_CLIPS` mappings and add presets per `docs/UNITY_PRESETS.md`.
+4) Alerts
+   - Hook Grafana panels to Prometheus metrics and add alert rules matching current thresholds.
+

--- a/packages/ksl_rules/rules.py
+++ b/packages/ksl_rules/rules.py
@@ -6,7 +6,7 @@ from packages.nlp_norm.normalize import parse_sino_korean_number
 
 # 매우 단순한 한국어 토크나이저(공백/기호 기준). 실제 서비스는 형태소 분석기 사용 권장.
 def tokenize_ko(text: str) -> List[str]:
-    seps = ",.!?;:()[]{}\"'\n\t"
+    seps = ".!?;:()[]{}\"'\n\t"
     for s in seps:
         text = text.replace(s, " ")
     # 숫자 구분 쉼표 제거: 1,234 → 1234

--- a/packages/sign_timeline/timeline.py
+++ b/packages/sign_timeline/timeline.py
@@ -19,15 +19,31 @@ _CLIPS = {
 DEFAULT_DUR = 650
 
 _FACE_CLIPS = {
+    # Alerts / disasters: 강조 표정
     "BREAKING": {"clip": "FACE_ALERT", "dur_ms": 500},
     "EARTHQUAKE": {"clip": "FACE_ALERT", "dur_ms": 700},
     "TYPHOON": {"clip": "FACE_ALERT", "dur_ms": 700},
+    "ALERT": {"clip": "FACE_ALERT", "dur_ms": 600},
+    "ADVISORY": {"clip": "FACE_ALERT", "dur_ms": 600},
+    # Severe weather keywords
+    "HEAVY_RAIN": {"clip": "FACE_ALERT", "dur_ms": 600},
+    "HEAVY_SNOW": {"clip": "FACE_ALERT", "dur_ms": 600},
 }
 
 _GAZE_CLIPS = {
+    # Keep attention forward for important segments
     "BREAKING": {"clip": "GAZE_FORWARD", "dur_ms": 500},
     "EARTHQUAKE": {"clip": "GAZE_FORWARD", "dur_ms": 700},
     "TYPHOON": {"clip": "GAZE_FORWARD", "dur_ms": 700},
+    "ALERT": {"clip": "GAZE_FORWARD", "dur_ms": 600},
+    "ADVISORY": {"clip": "GAZE_FORWARD", "dur_ms": 600},
+    # General weather terms keep steady gaze
+    "WEATHER": {"clip": "GAZE_FORWARD", "dur_ms": 500},
+    "RAIN": {"clip": "GAZE_FORWARD", "dur_ms": 500},
+    "SNOW": {"clip": "GAZE_FORWARD", "dur_ms": 500},
+    "SUNNY": {"clip": "GAZE_FORWARD", "dur_ms": 500},
+    "HEAVY_RAIN": {"clip": "GAZE_FORWARD", "dur_ms": 600},
+    "HEAVY_SNOW": {"clip": "GAZE_FORWARD", "dur_ms": 600},
 }
 
 

--- a/public/index.html
+++ b/public/index.html
@@ -41,6 +41,7 @@
     <div>timeline rate(1m): <b id="tl_rate">0</b>/s</div>
     <div>replace total: <b id="rep_total">0</b></div>
     <div>replace ratio: <span id="rep_ratio" class="badge">0</span></div>
+    <div>RL ratio: <span id="rl_ratio" class="badge">0</span></div>
     <div>ingest partial: <b id="ing_p">0</b></div>
     <div>ingest final: <b id="ing_f">0</b></div>
     <div>ingest rate(1m): <b id="ing_rate">0</b>/s</div>
@@ -201,6 +202,11 @@
         rctx.fillText('recent replace ratio', 10, 12);
       }
 
+      // simple moving-average helpers for hysteresis
+      const _avg = (arr) => arr.length ? arr.reduce((a,b)=>a+b,0)/arr.length : 0;
+      const p90Hist = [];
+      const repHist = [];
+      const rlHist = [];
       ws.onmessage = (ev) => {
         try {
           const data = JSON.parse(ev.data);
@@ -211,18 +217,36 @@
             document.getElementById('rep_total').textContent = s.timeline_replace_total ?? 0;
             (function(){
               const repEl = document.getElementById('rep_ratio');
-              const repRatio = s.timeline_replace_ratio ?? 0;
-              repEl.textContent = repRatio;
-              repEl.style.background = repRatio > (cfg.replace_ratio_warn||0.5) ? '#ff9aa2' : '#c2f0c2';
+              const repRatio = Number(s.timeline_replace_ratio ?? 0);
+              repEl.textContent = repRatio.toFixed(3);
+              repHist.push(repRatio); if (repHist.length>20) repHist.shift();
+              const repAvg = _avg(repHist);
+              const th = (cfg.replace_ratio_warn||0.5);
+              const bad = repAvg > th*1.05; // 5% margin
+              repEl.style.background = bad ? '#ff9aa2' : '#c2f0c2';
             })();
             document.getElementById('ing_p').textContent = s.ingest_partial_total ?? 0;
             document.getElementById('ing_f').textContent = s.ingest_final_total ?? 0;
             document.getElementById('ing_rate').textContent = s.ingest_rate_per_sec_1m ?? 0;
             (function(){
               const latEl = document.getElementById('last_lat');
-              const p90 = (s.latency_ms && s.latency_ms.p90) || 0;
+              const p90 = Number((s.latency_ms && s.latency_ms.p90) || 0);
               latEl.textContent = s.last_ingest_to_bc_ms ?? '-';
-              latEl.style.background = p90 > (cfg.latency_p90_warn_ms||1200) ? '#ff9aa2' : '#c2f0c2';
+              p90Hist.push(p90); if (p90Hist.length>10) p90Hist.shift();
+              const p90Avg = _avg(p90Hist);
+              const th = (cfg.latency_p90_warn_ms||1200);
+              const bad = p90Avg > th*1.05;
+              latEl.style.background = bad ? '#ff9aa2' : '#c2f0c2';
+            })();
+            (function(){
+              const rlEl = document.getElementById('rl_ratio');
+              const rlRatio = Number(s.rate_limit_ratio ?? 0);
+              rlEl.textContent = rlRatio.toFixed(3);
+              rlHist.push(rlRatio); if (rlHist.length>20) rlHist.shift();
+              const rlAvg = _avg(rlHist);
+              const th = (cfg.rate_limit_ratio_warn||0.1);
+              const bad = rlAvg > th*1.05;
+              rlEl.style.background = bad ? '#ff9aa2' : '#c2f0c2';
             })();
             document.getElementById('sess_count').textContent = s.session_count ?? 0;
             if (document.getElementById('rl_total')) document.getElementById('rl_total').textContent = s.ingest_rate_limited_total ?? 0;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+# Ensure project root is on sys.path for imports like `services.*` and `packages.*`
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+


### PR DESCRIPTION
…\n- Dashboard: RL ratio 배지 추가, 이동 평균+히스테리시스 적용\n- WS ingest: partial 중복 억제(공백/문장부호 정규화)\n- Routes: 정적 마운트 순서 조정, require_api_key 정리\n- Numbers: 토크나이저 콤마 처리 개선(1,234→1234)\n- Aux channels: ALERT/ADVISORY/HEAVY_* 및 WEATHER 계열 가시화 확대\n- Docs: PROGRESS_2025-09-13.md 추가\n- Tests: conftest.py로 import 경로 보장